### PR TITLE
fix: error de prettier + eslint in file '/lib/utils'

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
Erro ocasionado, pelo prettier junto com o Eslint,  no arquivo mencionado acima, lembrado que se nao estiver formatado pelo prettier, o eslint irá acusar,
Em faze de desenvolvimento ele roda normal, mais quando vai fazer o "build" em produção, o eslint segue a risca,
Então, quando for instalar um component do Shadcn , entre no arquivo que ele copiou e formart o mesmo.